### PR TITLE
feat: add logic to choose a dish by the user

### DIFF
--- a/src/Application/Component/Provider/DishProviderInterface.php
+++ b/src/Application/Component/Provider/DishProviderInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Meals\Application\Component\Provider;
+
+use Meals\Domain\Dish\Dish;
+
+interface DishProviderInterface
+{
+    public function setDish(Dish $dish);
+    public function getDish(int $dishId): Dish;
+}

--- a/src/Application/Component/Provider/PollResultProviderInterface.php
+++ b/src/Application/Component/Provider/PollResultProviderInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Meals\Application\Component\Provider;
+
+use Meals\Domain\Dish\Dish;
+use Meals\Domain\Employee\Employee;
+use Meals\Domain\Poll\Poll;
+use Meals\Domain\Poll\PollResult;
+
+interface PollResultProviderInterface
+{
+    public function createPollResult(Poll $poll, Employee $employee, Dish $dish): PollResult;
+    public function setPollResult(PollResult $pollResult);
+    public function getPollResult(): PollResult;
+}

--- a/src/Application/Component/Validator/Exception/PollResultIsNotAvailableException.php
+++ b/src/Application/Component/Validator/Exception/PollResultIsNotAvailableException.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Meals\Application\Component\Validator\Exception;
+
+class PollResultIsNotAvailableException extends \RuntimeException
+{
+
+}

--- a/src/Application/Component/Validator/PollResultIsAvailableValidator.php
+++ b/src/Application/Component/Validator/PollResultIsAvailableValidator.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Meals\Application\Component\Validator;
+
+use Meals\Application\Component\Validator\Exception\PollResultIsNotAvailableException;
+use Meals\Application\Constant\ValidatorConstant;
+
+class PollResultIsAvailableValidator
+{
+    public function validate(\DateTime $dateTime): void
+    {
+        if (!$this->isAvailableDateTime($dateTime)) {
+            throw new PollResultIsNotAvailableException();
+        }
+    }
+
+    private function isAvailableDateTime(\DateTime $dateTime): bool
+    {
+        $currentDay = $dateTime->format('l');
+        $currentTime = strtotime($dateTime->format('H:i:s'));
+
+        return ValidatorConstant::AVAILABLE_POLL_DAY === $currentDay &&
+          $currentTime >= strtotime(ValidatorConstant::POLL_START_TIME) &&
+          $currentTime < strtotime(ValidatorConstant::POLL_END_TIME);
+    }
+}

--- a/src/Application/Constant/ValidatorConstant.php
+++ b/src/Application/Constant/ValidatorConstant.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Meals\Application\Constant;
+
+final class ValidatorConstant
+{
+    public const AVAILABLE_POLL_DAY = 'Monday'; // доступный день голосования
+    public const POLL_START_TIME = '06:00'; // старт доступа к голосованию
+    public const POLL_END_TIME = '22:00'; // окончание голосования
+}

--- a/src/Application/Feature/Poll/UseCase/UserSetsDishToPollResult/Interactor.php
+++ b/src/Application/Feature/Poll/UseCase/UserSetsDishToPollResult/Interactor.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Meals\Application\Feature\Poll\UseCase\UserSetsDishToPollResult;
+
+use Meals\Application\Component\Provider\DishProviderInterface;
+use Meals\Application\Component\Provider\EmployeeProviderInterface;
+use Meals\Application\Component\Provider\PollProviderInterface;
+use Meals\Application\Component\Provider\PollResultProviderInterface;
+use Meals\Application\Component\Validator\PollIsActiveValidator;
+use Meals\Application\Component\Validator\PollResultIsAvailableValidator;
+use Meals\Application\Component\Validator\UserHasAccessToViewPollsValidator;
+use Meals\Domain\Poll\PollResult;
+
+class Interactor
+{
+    public function __construct(
+      private EmployeeProviderInterface $employeeProvider,
+      private PollProviderInterface $pollProvider,
+      private DishProviderInterface $dishProvider,
+      private PollResultIsAvailableValidator $pollResultIsAvailableValidator,
+      private UserHasAccessToViewPollsValidator $userHasAccessToPollsValidator,
+      private PollIsActiveValidator $pollIsActiveValidator,
+      private PollResultProviderInterface $pollResultProvider,
+    ) {}
+
+    public function userSetsDishToPollResult(int $employeeId, int $pollId, int $dishId, \DateTime $dateTime): PollResult
+    {
+        $employee = $this->employeeProvider->getEmployee($employeeId);
+        $poll = $this->pollProvider->getPoll($pollId);
+        $dish = $this->dishProvider->getDish($dishId);
+
+        $this->userHasAccessToPollsValidator->validate($employee->getUser());
+        $this->pollIsActiveValidator->validate($poll);
+        $this->pollResultIsAvailableValidator->validate($dateTime);
+
+        return $this->pollResultProvider->createPollResult($poll, $employee, $dish);
+    }
+}

--- a/tests/Constant/ValidatorConstant.php
+++ b/tests/Constant/ValidatorConstant.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace tests\Meals\Constant;
+
+final class ValidatorConstant
+{
+    public const TIMEZONE = 'Europe/Prague';
+
+    public const WRONG_DATETIME = '2022-01-24T23:03';
+    public const WRONG_DAY = '2022-01-25T15:03';
+
+    public const CORRECT_DATETIME = '2022-01-24T15:03';
+}

--- a/tests/Functional/Fake/Provider/FakeDishProvider.php
+++ b/tests/Functional/Fake/Provider/FakeDishProvider.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace tests\Meals\Functional\Fake\Provider;
+
+use Meals\Application\Component\Provider\DishProviderInterface;
+use Meals\Domain\Dish\Dish;
+
+class FakeDishProvider implements DishProviderInterface
+{
+    private Dish $dish;
+
+    public function setDish(Dish $dish): void
+    {
+        $this->dish = $dish;
+    }
+
+    public function getDish(int $dishId): Dish
+    {
+        return $this->dish;
+    }
+}

--- a/tests/Functional/Fake/Provider/FakePollResultProvider.php
+++ b/tests/Functional/Fake/Provider/FakePollResultProvider.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace tests\Meals\Functional\Fake\Provider;
+
+use Meals\Application\Component\Provider\PollResultProviderInterface;
+use Meals\Domain\Dish\Dish;
+use Meals\Domain\Employee\Employee;
+use Meals\Domain\Poll\Poll;
+use Meals\Domain\Poll\PollResult;
+
+class FakePollResultProvider implements PollResultProviderInterface
+{
+    private PollResult $pollResult;
+
+    public function createPollResult(Poll $poll, Employee $employee, Dish $dish): PollResult
+    {
+        $this->setPollResult(new PollResult(0, $poll, $employee, $dish, $employee->getFloor()));
+        return $this->getPollResult();
+    }
+
+    public function setPollResult(PollResult $pollResult)
+    {
+        $this->pollResult = $pollResult;
+    }
+
+    public function getPollResult(): PollResult
+    {
+        return $this->pollResult;
+    }
+}

--- a/tests/Functional/Interactor/UserSetsDishToPollResultTest.php
+++ b/tests/Functional/Interactor/UserSetsDishToPollResultTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace tests\Meals\Functional\Interactor;
+
+use Meals\Application\Component\Validator\Exception\PollResultIsNotAvailableException;
+use Meals\Application\Feature\Poll\UseCase\UserSetsDishToPollResult\Interactor;
+use Meals\Domain\Dish\Dish;
+use Meals\Domain\Dish\DishList;
+use Meals\Domain\Employee\Employee;
+use Meals\Domain\Menu\Menu;
+use Meals\Domain\Poll\Poll;
+use Meals\Domain\Poll\PollResult;
+use Meals\Domain\User\Permission\Permission;
+use Meals\Domain\User\Permission\PermissionList;
+use Meals\Domain\User\User;
+use tests\Meals\Constant\ValidatorConstant;
+use tests\Meals\Functional\Fake\Provider\FakeDishProvider;
+use tests\Meals\Functional\Fake\Provider\FakeEmployeeProvider;
+use tests\Meals\Functional\Fake\Provider\FakePollProvider;
+use tests\Meals\Functional\FunctionalTestCase;
+
+class UserSetsDishToPollResultTest extends FunctionalTestCase
+{
+    public function testSuccessful()
+    {
+        $pollResult = $this->performTestMethod(
+          $this->getEmployeeWithPermissions(),
+          $this->getPoll(true),
+          $this->getDish(),
+          new \DateTime(ValidatorConstant::CORRECT_DATETIME, new \DateTimeZone(ValidatorConstant::TIMEZONE))
+        );
+
+        verify($pollResult)->equals($pollResult);
+    }
+
+    public function testPollResultIsNotAvailable()
+    {
+        $this->expectException(PollResultIsNotAvailableException::class);
+
+        $pollResult = $this->performTestMethod(
+          $this->getEmployeeWithPermissions(),
+          $this->getPoll(true),
+          $this->getDish(),
+          new \DateTime(ValidatorConstant::WRONG_DATETIME, new \DateTimeZone(ValidatorConstant::TIMEZONE))
+        );
+
+        verify($pollResult)->equals($pollResult);
+    }
+
+    private function performTestMethod(Employee $employee, Poll $poll, Dish $dish, \DateTime $dateTime): PollResult
+    {
+        $this->getContainer()->get(FakeEmployeeProvider::class)->setEmployee($employee);
+        $this->getContainer()->get(FakePollProvider::class)->setPoll($poll);
+        $this->getContainer()->get(FakeDishProvider::class)->setDish($dish);
+
+        return $this->getContainer()->get(Interactor::class)->userSetsDishToPollResult(
+          $employee->getId(),
+          $poll->getId(),
+          $dish->getId(),
+          $dateTime
+        );
+    }
+
+    private function getEmployeeWithPermissions(): Employee
+    {
+        return new Employee(
+          1,
+          $this->getUserWithPermissions(),
+          4,
+          'Surname'
+        );
+    }
+
+    private function getUserWithPermissions(): User
+    {
+        return new User(
+          1,
+          new PermissionList(
+            [
+              new Permission(Permission::VIEW_ACTIVE_POLLS),
+            ]
+          ),
+        );
+    }
+
+    private function getDish(): Dish
+    {
+        return new Dish(
+          1,
+          'title',
+          'description'
+        );
+    }
+
+    private function getPoll(bool $active): Poll
+    {
+        return new Poll(
+          1,
+          $active,
+          new Menu(
+            1,
+            'title',
+            new DishList([]),
+          )
+        );
+    }
+}

--- a/tests/Unit/Application/Component/Validator/PollResultIsAvailableValidatorTest.php
+++ b/tests/Unit/Application/Component/Validator/PollResultIsAvailableValidatorTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace tests\Meals\Unit\Application\Component\Validator;
+
+use Meals\Application\Component\Validator\Exception\PollResultIsNotAvailableException;
+use Meals\Application\Component\Validator\PollResultIsAvailableValidator;
+use PHPUnit\Framework\TestCase;
+use tests\Meals\Constant\ValidatorConstant;
+
+class PollResultIsAvailableValidatorTest extends TestCase
+{
+    public function testSuccessful()
+    {
+        $validator = new PollResultIsAvailableValidator();
+        verify(
+          $validator->validate(new \DateTime(ValidatorConstant::CORRECT_DATETIME, new \DateTimeZone(ValidatorConstant::TIMEZONE)))
+        )->null();
+    }
+
+    public function testFailDay()
+    {
+        $this->expectException(PollResultIsNotAvailableException::class);
+
+        $validator = new PollResultIsAvailableValidator();
+        $validator->validate(new \DateTime(ValidatorConstant::WRONG_DAY, new \DateTimeZone(ValidatorConstant::TIMEZONE)));
+    }
+
+    public function testFailTime()
+    {
+        $this->expectException(PollResultIsNotAvailableException::class);
+
+        $validator = new PollResultIsAvailableValidator();
+        $validator->validate(new \DateTime(ValidatorConstant::WRONG_DATETIME, new \DateTimeZone(ValidatorConstant::TIMEZONE)));
+    }
+}


### PR DESCRIPTION
Functional:

Added functionality to select a dish by a user. The "userSetsDishToPollResult" method contains poll activity checks, user rights checks, poll day and time checks.

New providers (DishProvider and PollResultProvider) have been added to work with dishes and poll results.

A new validator has been added to check the day and time (PollResultIsAvailableValidator)

Tests:
Added PollResultIsAvailableValidatorTest and UserSetsDishToPollResultTest.

Cases for testing:
- the user selects a dish at the correct time and day
- on an unavailable day
- at unavailable time